### PR TITLE
Create Github Action to automate generation of the blocklist in different formats

### DIFF
--- a/.github/workflows/compile-lists.yml
+++ b/.github/workflows/compile-lists.yml
@@ -31,7 +31,7 @@ jobs:
         # https://github.com/natarii/vrchat-domain-blocklist
         #
         # Fetch the latest version of this file:
-        # https://raw.githubusercontent.com/natarii/vrchat-domain-blocklist/main/adblock-list.txt
+        # https://raw.githubusercontent.com/natarii/vrchat-domain-blocklist/main/generated/adblock-list.txt
         #
         # License:
         # CC Attribution 3.0 (http://creativecommons.org/licenses/by/3.0/)

--- a/.github/workflows/compile-lists.yml
+++ b/.github/workflows/compile-lists.yml
@@ -1,0 +1,59 @@
+name: Compile Lists
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  compile-hosts:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Compile into hosts file format
+      run: |
+        # Create the generated folder if it doesn't exist
+        mkdir -p generated
+
+        # Concatenate all hosts files into one
+        cat lists/*/* > generated/hosts
+
+    - name: Compile into adblock list format
+      run: |
+        echo "# VRChat AdAway blocklist
+        # Blocking ad providers and some tracking analytics that is injected to your VRChat instance
+        #
+        # Project home page:
+        # https://github.com/natarii/vrchat-domain-blocklist
+        #
+        # Fetch the latest version of this file:
+        # https://raw.githubusercontent.com/natarii/vrchat-domain-blocklist/main/adblock-list.txt
+        #
+        # License:
+        # CC Attribution 3.0 (http://creativecommons.org/licenses/by/3.0/)
+        #
+        # Contribution by:
+        # itsvrl
+        # Further changes and contributors maintained in the commit history at
+        # https://github.com/natarii/vrchat-domain-blocklist/commits/main
+        #
+        # Contribute:
+        # Create an issue at https://github.com/natarii/vrchat-domain-blocklist/issues
+        #
+        " > generated/adblock-list.txt
+        # Remove instances of 0.0.0.0 and add to file
+        sed 's/0.0.0.0 //' generated/hosts >> generated/adblock-list.txt
+
+    - name: Commit & Push changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "List Compiler Action"
+
+        git add generated/hosts
+        git add generated/adblock-list.txt
+        git commit -m "Compiled hosts files"
+        git push

--- a/generated/adblock-list.txt
+++ b/generated/adblock-list.txt
@@ -5,7 +5,7 @@
 # https://github.com/natarii/vrchat-domain-blocklist
 #
 # Fetch the latest version of this file:
-# https://raw.githubusercontent.com/natarii/vrchat-domain-blocklist/main/adblock-list.txt
+# https://raw.githubusercontent.com/natarii/vrchat-domain-blocklist/main/generated/adblock-list.txt
 #
 # License:
 # CC Attribution 3.0 (http://creativecommons.org/licenses/by/3.0/)

--- a/generated/adblock-list.txt
+++ b/generated/adblock-list.txt
@@ -1,0 +1,42 @@
+# VRChat AdAway blocklist
+# Blocking ad providers and some tracking analytics that is injected to your VRChat instance
+#
+# Project home page:
+# https://github.com/natarii/vrchat-domain-blocklist
+#
+# Fetch the latest version of this file:
+# https://raw.githubusercontent.com/natarii/vrchat-domain-blocklist/main/adblock-list.txt
+#
+# License:
+# CC Attribution 3.0 (http://creativecommons.org/licenses/by/3.0/)
+#
+# Contribution by:
+# itsvrl
+# Further changes and contributors maintained in the commit history at
+# https://github.com/natarii/vrchat-domain-blocklist/commits/main
+#
+# Contribute:
+# Create an issue at https://github.com/natarii/vrchat-domain-blocklist/issues
+#
+
+#used all over vrc client and sdk
+api.lab.amplitude.com
+api2.amplitude.com
+o1125869.ingest.sentry.io
+#no idea what will actually be used since it hasn't launched yet, these two already seen "in the wild"
+i.adli.ly
+t.adli.ly
+#prefab exploits a client vulnerability to bypass http request rate limiting
+api.yamachan.moe
+#rainy road, cruzeiro brasil, ...
+biakawaiibr.github.io
+acchosen.github.io
+m.k-cdn.xyz
+#b.search.kinashi.net #this breaks search, it's implemented serverside but just refers to url indices in the world
+#found in Idle Home, probably in others as well
+makimaki.dev
+#vr-m.net #breaks playback
+prismic.net #this breaks VRCanvas but i don't care
+#world exploits multiple client vulnerabilities, also spams client log to obfuscate what it's doing
+r.urei.si
+vrc.citrusxr.cyou

--- a/generated/hosts
+++ b/generated/hosts
@@ -1,0 +1,21 @@
+#used all over vrc client and sdk
+0.0.0.0 api.lab.amplitude.com
+0.0.0.0 api2.amplitude.com
+0.0.0.0 o1125869.ingest.sentry.io
+#no idea what will actually be used since it hasn't launched yet, these two already seen "in the wild"
+0.0.0.0 i.adli.ly
+0.0.0.0 t.adli.ly
+#prefab exploits a client vulnerability to bypass http request rate limiting
+0.0.0.0 api.yamachan.moe
+#rainy road, cruzeiro brasil, ...
+0.0.0.0 biakawaiibr.github.io
+0.0.0.0 acchosen.github.io
+0.0.0.0 m.k-cdn.xyz
+#0.0.0.0 b.search.kinashi.net #this breaks search, it's implemented serverside but just refers to url indices in the world
+#found in Idle Home, probably in others as well
+0.0.0.0 makimaki.dev
+#0.0.0.0 vr-m.net #breaks playback
+0.0.0.0 prismic.net #this breaks VRCanvas but i don't care
+#world exploits multiple client vulnerabilities, also spams client log to obfuscate what it's doing
+0.0.0.0 r.urei.si
+0.0.0.0 vrc.citrusxr.cyou


### PR DESCRIPTION
A while ago I noticed SuRoom collecting analytics of some kind and was curious why - it eventually lead me to finding this project. I saw [this comment](https://github.com/natarii/vrchat-domain-blocklist/pull/1#issuecomment-1756883693) and decided to go ahead and do it. Thanks for making this!

`generated/hosts` contains the list as it exists in a single file
`genereated/adblock-list.txt` contains the list in the format given in #1